### PR TITLE
.mergify.yml: update PR checks condition

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,7 +2,7 @@ pull_request_rules:
   - name: automatic merge successful scala-steward PRs
     conditions:
       - author=scala-steward
-      - "#status-failure=0"
+      - status-success=continuous-integration/travis-ci/pr
     actions:
       merge:
         method: merge


### PR DESCRIPTION
Didn't work with `#status-failure=0`, presumably because before a check completes its status is also not "failure"
Besides, since Mergify itself works with a check, if it were possible to express "all checks succeeded" that would create a catch-22
Unfortunately it seems that you have to hard-code which check(s) to depend on