### PR TITLE
Update Circe to 0.12.0-M3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ ThisBuild / version := "0.2"
 lazy val marker =
   project
     .settings(
-      libraryDependencies += "io.circe" %% "circe-core" % "0.11.1",
+      libraryDependencies += "io.circe" %% "circe-core" % "0.12.0-M3",
       libraryDependencies += "org.slf4j" % "slf4j-api" % "1.7.26"
     )
 


### PR DESCRIPTION
Mainly because it supports scala 2.13.0