### PR TITLE
ci.sbt: Use wildcards for scala versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.16, 3.3.4]
+        scala: [2.13.x, 3.3.x]
         java: [zulu@8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -85,22 +85,22 @@ jobs:
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
-      - name: Download target directories (2.13.16)
+      - name: Download target directories (2.13.x)
         uses: actions/download-artifact@v4
         with:
-          name: target-${{ matrix.os }}-2.13.16-${{ matrix.java }}
+          name: target-${{ matrix.os }}-2.13.x-${{ matrix.java }}
 
-      - name: Inflate target directories (2.13.16)
+      - name: Inflate target directories (2.13.x)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (3.3.4)
+      - name: Download target directories (3.3.x)
         uses: actions/download-artifact@v4
         with:
-          name: target-${{ matrix.os }}-3.3.4-${{ matrix.java }}
+          name: target-${{ matrix.os }}-3.3.x-${{ matrix.java }}
 
-      - name: Inflate target directories (3.3.4)
+      - name: Inflate target directories (3.3.x)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,8 +8,8 @@ pull_request_rules:
       - or:
           - author=scala-steward
           - author=nafg-scala-steward[bot]
-      - check-success=Build and Test (ubuntu-latest, 2.13.16, zulu@8)
-      - check-success=Build and Test (ubuntu-latest, 3.3.4, zulu@8)
+      - check-success=Build and Test (ubuntu-latest, 2.13.x, zulu@8)
+      - check-success=Build and Test (ubuntu-latest, 3.3.x, zulu@8)
     actions:
         queue:
             name: default

--- a/ci.sbt
+++ b/ci.sbt
@@ -7,6 +7,7 @@ inThisBuild(
     ),
     dynverGitDescribeOutput ~= (_.map(o => o.copy(dirtySuffix = sbtdynver.GitDirtySuffix("")))),
     dynverSonatypeSnapshots             := true,
+    githubWorkflowScalaVersions         := githubWorkflowScalaVersions.value.map(_.replaceFirst("\\d+$", "x")),
     githubWorkflowTargetTags ++= Seq("v*"),
     githubWorkflowPublishTargetBranches := Seq(RefPredicate.StartsWith(Ref.Tag("v"))),
     githubWorkflowPublish               := Seq(


### PR DESCRIPTION
This way, .mergify.yml won't need to be updated every time a new version is released.

This should also reduce merge conflicts.
