### PR TITLE
feat!: Update to logback 1.5 and include key-value pairs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.13.x, 3.3.x]
-        java: [zulu@8]
+        java: [zulu@11]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -32,12 +32,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (zulu@8)
-        if: matrix.java == 'zulu@8'
+      - name: Setup Java (zulu@11)
+        if: matrix.java == 'zulu@11'
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 8
+          java-version: 11
           cache: sbt
 
       - name: Setup sbt
@@ -66,7 +66,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [3.3.5]
-        java: [zulu@8]
+        java: [zulu@11]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -74,12 +74,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (zulu@8)
-        if: matrix.java == 'zulu@8'
+      - name: Setup Java (zulu@11)
+        if: matrix.java == 'zulu@11'
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 8
+          java-version: 11
           cache: sbt
 
       - name: Setup sbt

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,8 +8,8 @@ pull_request_rules:
       - or:
           - author=scala-steward
           - author=nafg-scala-steward[bot]
-      - check-success=Build and Test (ubuntu-latest, 2.13.x, zulu@8)
-      - check-success=Build and Test (ubuntu-latest, 3.3.x, zulu@8)
+      - check-success=Build and Test (ubuntu-latest, 2.13.x, zulu@11)
+      - check-success=Build and Test (ubuntu-latest, 3.3.x, zulu@11)
     actions:
         queue:
             name: default

--- a/appender/src/test/scala/io/github/nafg/cloudlogging/appender/CloudJsonLoggingAppenderTests.scala
+++ b/appender/src/test/scala/io/github/nafg/cloudlogging/appender/CloudJsonLoggingAppenderTests.scala
@@ -4,10 +4,12 @@ import ch.qos.logback.classic.spi.*
 import ch.qos.logback.classic.{Level, LoggerContext}
 import com.google.cloud.logging.{Payload, Severity}
 import io.circe.Json
+import io.github.nafg.cloudlogging.appender.CloudJsonLoggingAppender.marker
 import io.github.nafg.cloudlogging.marker.JsonMarker
 import org.scalatest.Inside.*
 import org.scalatest.funsuite.AnyFunSuite
 import org.slf4j.Marker
+import org.slf4j.event.KeyValuePair
 
 import java.util
 import scala.jdk.CollectionConverters.*
@@ -27,31 +29,33 @@ class CloudJsonLoggingAppenderTests extends AnyFunSuite {
         new ThrowableProxy(new RuntimeException("Some error"))
       override def getCallerData: Array[StackTraceElement]     = Array.empty
       override def hasCallerData: Boolean                      = false
-      override def getMarker: Marker                           =
-        JsonMarker("testMarker", Json.obj("key" -> Json.fromString("value")))
+      override def getMarkerList: util.List[Marker]            =
+        List[Marker](JsonMarker("testMarker", Json.obj("markerKey" -> Json.fromString("markerValue")))).asJava
       override def getMDCPropertyMap: util.Map[String, String] =
         Map.empty[String, String].asJava
       override def getMdc: util.Map[String, String]            = getMDCPropertyMap
       override val getTimeStamp: Long                          = System.currentTimeMillis()
+      override def getNanoseconds: Int                         = 0
       override def prepareForDeferredProcessing(): Unit        = ()
+      override def getSequenceNumber: Long                     = 0
+      override def getKeyValuePairs: util.List[KeyValuePair]   = List(new KeyValuePair("pairKey", "pairValue")).asJava
     }
 
     val logEntry = CloudJsonLoggingAppender.logEntryFor(loggingEvent)
 
     assert(logEntry.getSeverity == Severity.ERROR)
 
-    val data: util.Map[String, AnyRef] =
-      logEntry.getPayload[Payload.JsonPayload].getDataAsMap
+    val data = logEntry.getPayload[Payload.JsonPayload].getDataAsMap.asScala
 
-    inside(data.get("message")) { case message: String =>
+    inside(data.get("message")) { case Some(message: String) =>
       assert(message.startsWith(loggingEvent.getMessage))
     }
 
-    inside(data.get("marker")) { case marker: util.Map[String, String] =>
-      assert(marker.get("name") == "testMarker")
+    inside(data.get("markers")) { case Some(markers: util.List[util.Map[String, String]]) =>
+      assert(markers.get(0).get("name") == "testMarker")
     }
 
-    inside(data.get("throwable")) { case throwable: util.Map[String, String] =>
+    inside(data.get("throwable")) { case Some(throwable: util.Map[k, v]) =>
       assert(throwable.get("message") == "Some error")
       assert(throwable.containsKey("stack"))
     }

--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,7 @@ lazy val appender =
     .settings(
       adjustScalacOptions,
       libraryDependencies += "com.google.cloud" % "google-cloud-logging-logback" % "0.132.5-alpha",
+      libraryDependencies += "ch.qos.logback"   % "logback-classic"              % "1.5.18",
       libraryDependencies += "org.scalatest"   %% "scalatest"                    % "3.2.19" % Test
     )
 

--- a/ci.sbt
+++ b/ci.sbt
@@ -7,6 +7,7 @@ inThisBuild(
     ),
     dynverGitDescribeOutput ~= (_.map(o => o.copy(dirtySuffix = sbtdynver.GitDirtySuffix("")))),
     dynverSonatypeSnapshots             := true,
+    githubWorkflowJavaVersions          := Seq(JavaSpec.zulu("11")),
     githubWorkflowScalaVersions         := githubWorkflowScalaVersions.value.map(_.replaceFirst("\\d+$", "x")),
     githubWorkflowTargetTags ++= Seq("v*"),
     githubWorkflowPublishTargetBranches := Seq(RefPredicate.StartsWith(Ref.Tag("v"))),


### PR DESCRIPTION
JSON payload now includes 'markers' instead of 'marker,'
and includes 'values' for key-value pairs
