### PR TITLE
CI: bump JDK to zulu@17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.13.x, 3.3.x]
-        java: [zulu@11]
+        java: [zulu@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -32,12 +32,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (zulu@11)
-        if: matrix.java == 'zulu@11'
+      - name: Setup Java (zulu@17)
+        if: matrix.java == 'zulu@17'
         uses: actions/setup-java@v5
         with:
           distribution: zulu
-          java-version: 11
+          java-version: 17
           cache: sbt
 
       - name: Setup sbt
@@ -66,7 +66,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [3.3.8]
-        java: [zulu@11]
+        java: [zulu@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -74,12 +74,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (zulu@11)
-        if: matrix.java == 'zulu@11'
+      - name: Setup Java (zulu@17)
+        if: matrix.java == 'zulu@17'
         uses: actions/setup-java@v5
         with:
           distribution: zulu
-          java-version: 11
+          java-version: 17
           cache: sbt
 
       - name: Setup sbt

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,8 +8,8 @@ pull_request_rules:
       - or:
           - author=scala-steward
           - author=nafg-scala-steward[bot]
-      - check-success=Build and Test (ubuntu-latest, 2.13.x, zulu@11)
-      - check-success=Build and Test (ubuntu-latest, 3.3.x, zulu@11)
+      - check-success=Build and Test (ubuntu-latest, 2.13.x, zulu@17)
+      - check-success=Build and Test (ubuntu-latest, 3.3.x, zulu@17)
     actions:
         queue:
             name: default

--- a/ci.sbt
+++ b/ci.sbt
@@ -13,7 +13,7 @@ inThisBuild(
         })
       },
     dynverSonatypeSnapshots             := true,
-    githubWorkflowJavaVersions          := Seq(JavaSpec.zulu("11")),
+    githubWorkflowJavaVersions          := Seq(JavaSpec.zulu("17")),
     githubWorkflowScalaVersions         := githubWorkflowScalaVersions.value.map(_.replaceFirst("\\d+$", "x")),
     githubWorkflowTargetTags ++= Seq("v*"),
     githubWorkflowPublishTargetBranches := Seq(RefPredicate.StartsWith(Ref.Tag("v"))),


### PR DESCRIPTION
`githubWorkflowJavaVersions` was pinned to `zulu@11`. sbt 2.x requires JDK 17+, so scala-steward's "Update sbt to 2.0.x" PR cannot pass CI on JDK 11.

Bumps only the version — `JavaSpec.zulu("11")` -> `JavaSpec.zulu("17")` — leaving the vendor as Zulu, then regenerates the workflow with `githubWorkflowGenerate`. The generated diff touches `java-version` and the `zulu@N` labels only; `distribution: zulu` is unchanged. `.mergify.yml` check names move with the labels (the version is embedded in them), via sbt-mergify-github-actions.

Split into two commits per the usual convention: the hand-written setting, then the regeneration.

Verified locally on JDK 17: `githubWorkflowCheck` passes and `+test` passes on both 2.13.x and 3.3.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration and publishing workflows to use Java 17.
  * Updated automated merge checks to validate Scala 2.13 and Scala 3.3 builds with Java 17.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->